### PR TITLE
Add simple WordPress site scaffold with MV Simple theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# WordPress core files not tracked in this repository
+wp-admin/
+wp-includes/
+
+# Uploads and cache directories
+wp-content/uploads/
+wp-content/cache/
+wp-content/upgrade/
+
+# OS / Editor
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+*.swp
+.idea/
+.vscode/
+
+# Local environment configuration
+wp-config-local.php
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# mv-custom-wordpress-theme
+# MV Simple WordPress Site
+
+This repository contains a minimal WordPress project that focuses on a single custom theme (`mv-simple`) and a `wp-config.php` file that sources all secrets from environment variables. It can be dropped into a full WordPress core installation or previewed locally using the included development bootstrapper.
+
+## Getting started
+
+1. Download the official [WordPress core](https://wordpress.org/download/) release and extract it into this directory, or symlink the `wp-admin` and `wp-includes` folders from an existing installation.
+2. Copy the contents of this repository over the WordPress root.
+3. Provide the following environment variables (for example via a `.env` file or your hosting platform) so that `wp-config.php` can read the secrets securely:
+
+   ```bash
+   export WP_DB_NAME=your_database
+   export WP_DB_USER=your_user
+   export WP_DB_PASSWORD=super_secret_password
+   export WP_DB_HOST=localhost
+   export WP_TABLE_PREFIX=wp_
+   export WP_AUTH_KEY=...
+   export WP_SECURE_AUTH_KEY=...
+   export WP_LOGGED_IN_KEY=...
+   export WP_NONCE_KEY=...
+   export WP_AUTH_SALT=...
+   export WP_SECURE_AUTH_SALT=...
+   export WP_LOGGED_IN_SALT=...
+   export WP_NONCE_SALT=...
+   ```
+
+4. (Optional) Define `WP_HOME`, `WP_SITEURL`, or `WP_DEBUG` if your environment requires them.
+5. Visit the WordPress dashboard and activate the **MV Simple Theme**.
+
+### Preview without WordPress
+
+If you open `index.php` without having WordPress core available, the `dev-bootstrap.php` file inside the theme renders a static preview so you can see the design quickly.
+
+## Theme features
+
+- Responsive hero section with configurable text (via Customizer values).
+- Clean card layout for posts with support for featured images and categories.
+- Navigation menus for both header and footer locations.
+- Sidebar widget area and sensible defaults for new installs.
+
+Feel free to extend the theme for your project needs.

--- a/index.php
+++ b/index.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Front controller for the WordPress application.
+ *
+ * This file mimics the stock WordPress entry point so the project can be
+ * dropped into a full WordPress installation without modification.
+ */
+
+define('WP_USE_THEMES', true);
+
+require __DIR__ . '/wp-blog-header.php';

--- a/wp-blog-header.php
+++ b/wp-blog-header.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Bootstrap file responsible for loading WordPress.
+ *
+ * When the full WordPress core is unavailable (for example while developing
+ * this theme in isolation) a lightweight bootstrapper from the theme is used
+ * so the templates can still be previewed.
+ */
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+$wpLoad = __DIR__ . '/wp-load.php';
+
+if (file_exists($wpLoad)) {
+    require_once $wpLoad;
+    if (function_exists('wp')) {
+        wp();
+    }
+    if (defined('WPINC')) {
+        require_once ABSPATH . WPINC . '/template-loader.php';
+    }
+    return;
+}
+
+require __DIR__ . '/wp-content/themes/mv-simple/dev-bootstrap.php';

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WordPress configuration file for the MV simple site.
+ *
+ * Sensitive values are injected from environment secrets so nothing
+ * confidential is stored in the repository.
+ */
+
+$env = static function (string $key, string $default = ''): string {
+    $value = getenv($key);
+    if ($value === false) {
+        return $default;
+    }
+    return $value;
+};
+
+// Database settings supplied from secrets.
+define('DB_NAME', $env('WP_DB_NAME', 'database_name'));
+define('DB_USER', $env('WP_DB_USER', 'database_user'));
+define('DB_PASSWORD', $env('WP_DB_PASSWORD', 'database_password'));
+define('DB_HOST', $env('WP_DB_HOST', 'localhost'));
+
+define('DB_CHARSET', $env('WP_DB_CHARSET', 'utf8mb4'));
+define('DB_COLLATE', $env('WP_DB_COLLATE', ''));
+
+$table_prefix = $env('WP_TABLE_PREFIX', 'wp_');
+
+define('AUTH_KEY', $env('WP_AUTH_KEY'));
+define('SECURE_AUTH_KEY', $env('WP_SECURE_AUTH_KEY'));
+define('LOGGED_IN_KEY', $env('WP_LOGGED_IN_KEY'));
+define('NONCE_KEY', $env('WP_NONCE_KEY'));
+define('AUTH_SALT', $env('WP_AUTH_SALT'));
+define('SECURE_AUTH_SALT', $env('WP_SECURE_AUTH_SALT'));
+define('LOGGED_IN_SALT', $env('WP_LOGGED_IN_SALT'));
+define('NONCE_SALT', $env('WP_NONCE_SALT'));
+
+// Optional URLs for headless deployments.
+if ($home = $env('WP_HOME')) {
+    define('WP_HOME', $home);
+}
+if ($siteUrl = $env('WP_SITEURL')) {
+    define('WP_SITEURL', $siteUrl);
+}
+
+define('WP_DEBUG', filter_var($env('WP_DEBUG', 'false'), FILTER_VALIDATE_BOOLEAN));
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+// Allow local overrides (kept out of version control).
+$localConfig = __DIR__ . '/wp-config-local.php';
+if (file_exists($localConfig)) {
+    require_once $localConfig;
+}
+
+$wpSettings = ABSPATH . 'wp-settings.php';
+if (file_exists($wpSettings)) {
+    require_once $wpSettings;
+    return;
+}
+
+// Development fallback keeps the theme previewable without the full core.
+require_once ABSPATH . 'wp-content/themes/mv-simple/dev-bootstrap.php';

--- a/wp-content/index.php
+++ b/wp-content/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/wp-content/themes/mv-simple/dev-bootstrap.php
+++ b/wp-content/themes/mv-simple/dev-bootstrap.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Lightweight bootstrap to preview the theme without the full WordPress core.
+ */
+
+declare(strict_types=1);
+
+$themeRoot = __DIR__;
+$stylesheet = file_get_contents($themeRoot . '/style.css');
+$stylesheet = preg_replace('~/\*.*?\*/~s', '', (string) $stylesheet);
+?><!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MV Simple Theme Preview</title>
+    <style><?php echo $stylesheet; ?></style>
+</head>
+<body>
+<div class="site">
+    <header class="site-header">
+        <h1 class="site-title">MV Simple Theme</h1>
+        <p class="site-description">A quick preview without WordPress.</p>
+    </header>
+    <nav class="site-navigation">
+        <ul>
+            <li><a href="#home">Home</a></li>
+            <li><a href="#features">Features</a></li>
+            <li><a href="#contact">Contact</a></li>
+        </ul>
+    </nav>
+    <section class="hero">
+        <h2 class="hero__title">Beautiful WordPress Experiences</h2>
+        <p class="hero__subtitle">Launch marketing sites, publish content, and tell your story with a clean, modern layout that focuses on readability.</p>
+        <a class="hero__cta" href="#primary-content">Explore the site</a>
+    </section>
+    <main id="primary-content" class="content-area">
+        <article class="post-card">
+            <header class="post-card__header">
+                <div class="post-card__meta">
+                    <span class="post-card__date">Today</span>
+                    <span class="post-card__categories">News</span>
+                </div>
+                <h2 class="post-card__title"><a href="#">Designing delightful customer journeys</a></h2>
+            </header>
+            <div class="post-card__content">
+                <div class="post-card__excerpt">
+                    <p>Use this preview to get a feel for the MV Simple theme without a full WordPress stack. Replace it with real content once WordPress core is installed.</p>
+                </div>
+            </div>
+        </article>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; <?php echo date('Y'); ?> MV Simple Theme.</p>
+        <p>Crafted with WordPress and the MV Simple theme.</p>
+    </footer>
+</div>
+</body>
+</html>

--- a/wp-content/themes/mv-simple/footer.php
+++ b/wp-content/themes/mv-simple/footer.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Theme footer.
+ *
+ * @package MV_Simple
+ */
+?>
+    <footer class="site-footer">
+        <p>&copy; <?php echo esc_html(date('Y')); ?> <?php bloginfo('name'); ?>.</p>
+        <p><?php esc_html_e('Crafted with WordPress and the MV Simple theme.', 'mv-simple'); ?></p>
+        <?php
+        wp_nav_menu([
+            'theme_location' => 'footer',
+            'container'      => false,
+            'menu_class'     => '',
+            'fallback_cb'    => '__return_empty_string',
+        ]);
+        ?>
+    </footer>
+</div>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/mv-simple/front-page.php
+++ b/wp-content/themes/mv-simple/front-page.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Front page template.
+ *
+ * @package MV_Simple
+ */
+
+get_header();
+?>
+<section class="hero">
+    <h2 class="hero__title"><?php echo esc_html(get_theme_mod('mv_simple_hero_title', __('Beautiful WordPress Experiences', 'mv-simple'))); ?></h2>
+    <p class="hero__subtitle"><?php echo esc_html(get_theme_mod('mv_simple_hero_subtitle', __('Launch marketing sites, publish content, and tell your story with a clean, modern layout that focuses on readability.', 'mv-simple'))); ?></p>
+    <a class="hero__cta" href="<?php echo esc_url(get_theme_mod('mv_simple_hero_button_url', '#primary-content')); ?>"><?php echo esc_html(get_theme_mod('mv_simple_hero_button_text', __('Explore the site', 'mv-simple'))); ?></a>
+</section>
+<main id="primary-content" class="content-area">
+    <?php if (have_posts()) : ?>
+        <?php while (have_posts()) : the_post(); ?>
+            <?php get_template_part('template-parts/content', get_post_type()); ?>
+        <?php endwhile; ?>
+        <?php the_posts_navigation(); ?>
+    <?php else : ?>
+        <?php get_template_part('template-parts/content', 'none'); ?>
+    <?php endif; ?>
+</main>
+<?php get_footer();

--- a/wp-content/themes/mv-simple/functions.php
+++ b/wp-content/themes/mv-simple/functions.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Functions for the MV Simple theme.
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('mv_simple_setup')) {
+    function mv_simple_setup(): void
+    {
+        add_theme_support('title-tag');
+        add_theme_support('post-thumbnails');
+        add_theme_support('automatic-feed-links');
+
+        register_nav_menus([
+            'primary' => __('Primary Menu', 'mv-simple'),
+            'footer'  => __('Footer Menu', 'mv-simple'),
+        ]);
+    }
+}
+add_action('after_setup_theme', 'mv_simple_setup');
+
+if (!function_exists('mv_simple_enqueue_assets')) {
+    function mv_simple_enqueue_assets(): void
+    {
+        wp_enqueue_style('mv-simple-style', get_stylesheet_uri(), [], wp_get_theme()->get('Version'));
+        wp_enqueue_style(
+            'mv-simple-fonts',
+            'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap',
+            [],
+            null
+        );
+    }
+}
+add_action('wp_enqueue_scripts', 'mv_simple_enqueue_assets');
+
+if (!function_exists('mv_simple_widgets_init')) {
+    function mv_simple_widgets_init(): void
+    {
+        register_sidebar([
+            'name'          => __('Sidebar', 'mv-simple'),
+            'id'            => 'sidebar-1',
+            'description'   => __('Add widgets here to appear in the sidebar.', 'mv-simple'),
+            'before_widget' => '<section id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</section>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        ]);
+    }
+}
+add_action('widgets_init', 'mv_simple_widgets_init');

--- a/wp-content/themes/mv-simple/header.php
+++ b/wp-content/themes/mv-simple/header.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Theme header.
+ *
+ * @package MV_Simple
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<div class="site">
+    <header class="site-header">
+        <h1 class="site-title"><a href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a></h1>
+        <p class="site-description"><?php bloginfo('description'); ?></p>
+    </header>
+    <nav class="site-navigation" aria-label="<?php esc_attr_e('Primary Navigation', 'mv-simple'); ?>">
+        <?php
+        wp_nav_menu([
+            'theme_location' => 'primary',
+            'container'      => false,
+            'menu_class'     => '',
+            'fallback_cb'    => static function (): void {
+                echo '<ul><li><a href="' . esc_url(home_url('/')) . '">' . esc_html__('Home', 'mv-simple') . '</a></li></ul>';
+            },
+        ]);
+        ?>
+    </nav>

--- a/wp-content/themes/mv-simple/index.php
+++ b/wp-content/themes/mv-simple/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Default template.
+ *
+ * @package MV_Simple
+ */
+
+get_header();
+?>
+<main class="content-area">
+    <?php if (have_posts()) : ?>
+        <?php while (have_posts()) : the_post(); ?>
+            <?php get_template_part('template-parts/content', get_post_type()); ?>
+        <?php endwhile; ?>
+        <?php the_posts_navigation(); ?>
+    <?php else : ?>
+        <?php get_template_part('template-parts/content', 'none'); ?>
+    <?php endif; ?>
+</main>
+<?php get_footer();

--- a/wp-content/themes/mv-simple/style.css
+++ b/wp-content/themes/mv-simple/style.css
@@ -1,0 +1,192 @@
+/*
+Theme Name: MV Simple Theme
+Theme URI: https://example.com/mv-simple
+Author: MV Themes
+Author URI: https://example.com
+Description: A lightweight theme used for demonstration inside the kata.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: mv-simple
+*/
+
+:root {
+    --mv-primary: #1f4f8b;
+    --mv-secondary: #f0f4f8;
+    --mv-accent: #fcbf49;
+    --mv-text: #1c1c1c;
+    --mv-muted: #6c757d;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    color: var(--mv-text);
+    background-color: #ffffff;
+    margin: 0;
+}
+
+a {
+    color: var(--mv-primary);
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    text-decoration: underline;
+}
+
+.site {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.site-header {
+    background: linear-gradient(135deg, var(--mv-primary), #0f2f54);
+    color: #ffffff;
+    padding: 1.5rem 1rem;
+    text-align: center;
+}
+
+.site-title {
+    margin: 0;
+    font-size: 2rem;
+    letter-spacing: 0.05em;
+}
+
+.site-description {
+    margin: 0.5rem 0 0;
+    font-weight: 300;
+}
+
+.site-navigation {
+    background-color: #0f2f54;
+}
+
+.site-navigation ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.site-navigation li {
+    margin: 0.25rem 0.75rem;
+}
+
+.site-navigation a {
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.hero {
+    background-color: var(--mv-secondary);
+    padding: 4rem 1.5rem;
+    text-align: center;
+}
+
+.hero__title {
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+}
+
+.hero__subtitle {
+    max-width: 60ch;
+    margin: 0 auto 2rem;
+    color: var(--mv-muted);
+}
+
+.hero__cta {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background-color: var(--mv-accent);
+    color: #0f2f54;
+    border-radius: 999px;
+    font-weight: 700;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__cta:hover,
+.hero__cta:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 30px rgba(252, 191, 73, 0.35);
+}
+
+.content-area {
+    flex: 1;
+    width: min(1100px, 92vw);
+    margin: 0 auto;
+    padding: 3rem 0;
+}
+
+.post-card {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 15px 35px rgba(15, 47, 84, 0.07);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post-card:hover,
+.post-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 50px rgba(15, 47, 84, 0.12);
+}
+
+.post-card__meta {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--mv-muted);
+}
+
+.post-card__title {
+    font-size: 1.75rem;
+    margin: 1rem 0 0.5rem;
+}
+
+.post-card__excerpt {
+    line-height: 1.6;
+    color: var(--mv-muted);
+}
+
+.widget-area {
+    background-color: var(--mv-secondary);
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+}
+
+.site-footer {
+    background-color: #0f2f54;
+    color: #ffffff;
+    text-align: center;
+    padding: 2rem 1rem;
+    margin-top: auto;
+}
+
+.site-footer p {
+    margin: 0.25rem 0;
+    font-size: 0.875rem;
+}
+
+@media (max-width: 768px) {
+    .site-navigation ul {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .post-card {
+        padding: 1.5rem;
+    }
+}

--- a/wp-content/themes/mv-simple/template-parts/content-none.php
+++ b/wp-content/themes/mv-simple/template-parts/content-none.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Template part for displaying a message when no posts are found.
+ *
+ * @package MV_Simple
+ */
+?>
+<section class="post-card">
+    <header class="post-card__header">
+        <h2 class="post-card__title"><?php esc_html_e('Nothing here yet', 'mv-simple'); ?></h2>
+    </header>
+    <div class="post-card__excerpt">
+        <p><?php esc_html_e('Ready to publish your first post? Start writing in the WordPress dashboard.', 'mv-simple'); ?></p>
+        <?php if (current_user_can('publish_posts')) : ?>
+            <p><a class="hero__cta" href="<?php echo esc_url(admin_url('post-new.php')); ?>"><?php esc_html_e('Add a new post', 'mv-simple'); ?></a></p>
+        <?php endif; ?>
+    </div>
+</section>

--- a/wp-content/themes/mv-simple/template-parts/content.php
+++ b/wp-content/themes/mv-simple/template-parts/content.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Template part for displaying posts.
+ *
+ * @package MV_Simple
+ */
+?>
+<article id="post-<?php the_ID(); ?>" <?php post_class('post-card'); ?>>
+    <header class="post-card__header">
+        <div class="post-card__meta">
+            <span class="post-card__date"><?php echo esc_html(get_the_date()); ?></span>
+            <?php if (get_post_type() === 'post') : ?>
+                <span class="post-card__categories"><?php the_category(', '); ?></span>
+            <?php endif; ?>
+        </div>
+        <?php the_title('<h2 class="post-card__title"><a href="' . esc_url(get_permalink()) . '">', '</a></h2>'); ?>
+    </header>
+
+    <div class="post-card__content">
+        <?php if (has_post_thumbnail()) : ?>
+            <div class="post-card__thumbnail">
+                <a href="<?php the_permalink(); ?>">
+                    <?php the_post_thumbnail('large'); ?>
+                </a>
+            </div>
+        <?php endif; ?>
+
+        <div class="post-card__excerpt">
+            <?php the_excerpt(); ?>
+        </div>
+    </div>
+</article>


### PR DESCRIPTION
## Summary
- add an environment-driven `wp-config.php` and bootstrapper so the site can run with or without a full WordPress core
- introduce the MV Simple theme with hero, navigation, and content templates for a polished landing experience
- document setup steps and required secrets for configuring the site securely

## Testing
- find . -name '*.php' -not -path './.git/*' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d6f8c9b8e0833197a2c8d3d6caf840